### PR TITLE
Testreport parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ before_install:
  - docker exec -i fc11-testreport ls -altr /MITgcm
  - docker exec -i fc11-testreport yum install python-pip
  - docker exec -i fc11-testreport yum install gcc-gfortran
+ - docker exec -i fc11-testreport yum install python-argparse
 
 script: 
  - echo `pwd`
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_barotropic_gyre"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_barotropic_gyre | tee tutorial_barotropic_gyre/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_barotropic_gyre/testreport_out.txt' -threshold 15"

--- a/verification/verification_parser.py
+++ b/verification/verification_parser.py
@@ -1,0 +1,51 @@
+"""Parse verification outputs."""
+
+import re
+
+def verification_parser(filename, threshold):
+    with open(filename) as f:
+        lines = f.readlines()
+
+        first_match = True
+
+        # extract lines from output
+        for i, line in enumerate(lines):
+            if line[:5] == '2 d e':
+                if first_match:
+                    # skip the first match, since it doesn't contain output,
+                    # but set to false to catch next matches.
+                    first_match = False
+                else:
+                    test_results = lines[i+2]
+
+        # split test_results into a list with values for each number. 
+        # this uses spaces and the < > characters to separate the numbers.
+        test_results = re.split('[ ><]',test_results)
+        # ignore the Genmake, depend, make, and run checks, as well as
+        # the "pass" or "fail" and test name at the end of the line
+        test_results = test_results[4:-3]
+        # convert to floats
+        dp_similarity = []
+        for i, x in enumerate(test_results):
+            try:
+                dp_similarity.append(float(x))
+            except ValueError:
+                pass
+
+        assert all(elements > threshold for elements in dp_similarity)
+
+if __name__ == '__main__':
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Check that verification simulation passed the test.')
+
+    parser.add_argument('-filename', type=str, 
+                        help='path to output file from the verification test')
+
+    parser.add_argument('-threshold', type=int, default=15, 
+                        help='number of decimal places of similarity required for test to pass')
+
+    args = parser.parse_args()
+
+    verification_parser(**vars(args))


### PR DESCRIPTION
A first attempt at a python function to parse the output from testreport. This is very much geared towards running on Travis, rather than being useful for people - `testreport` is already a very good testing framework for someone who doesn't need an automated detection of failure.

The output must be piped to a file, which is later parsed by the python function. At the moment, this function does not deal with additional experiments. 

Issues for discussion:
- this does not use the python unit testing framework, do we want to do that?
- it currently ignores the "pass" or "fail" from `testreport`, and instead uses `threshold` to decide if the test passed.
