### PR TITLE
allow for multiple subtests, expand list of tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_advection_in_gyre/testreport_out.txt' -threshold 15"
  # tutorial baroclinic gyre
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_baroclinic_gyre | tee tutorial_baroclinic_gyre/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_baroclinic_gyre/testreport_out.txt' -threshold 15"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_baroclinic_gyre/testreport_out.txt' -threshold 13"
  # tutorial barotropic gyre
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_barotropic_gyre | tee tutorial_barotropic_gyre/testreport_out.txt"
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_barotropic_gyre/testreport_out.txt' -threshold 15"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,27 @@ before_install:
 
 script: 
  - echo `pwd`
+ # tutorial advection in gyre
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_advection_in_gyre | tee tutorial_advection_in_gyre/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_advection_in_gyre/testreport_out.txt' -threshold 15"
+ # tutorial baroclinic gyre
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_baroclinic_gyre | tee tutorial_baroclinic_gyre/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_baroclinic_gyre/testreport_out.txt' -threshold 15"
+ # tutorial barotropic gyre
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_barotropic_gyre | tee tutorial_barotropic_gyre/testreport_out.txt"
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_barotropic_gyre/testreport_out.txt' -threshold 15"
+ # tutorial cfc offline
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_cfc_offline | tee tutorial_cfc_offline/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_cfc_offline/testreport_out.txt' -threshold 15"
+ # tutorial deep convection
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_deep_convection | tee tutorial_deep_convection/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_deep_convection/testreport_out.txt' -threshold 15 15"
+ # tutorial global oce biogeo
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_global_oce_biogeo | tee tutorial_global_oce_biogeo/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_biogeo/testreport_out.txt' -threshold 12"
+ # tutorial global oce in p
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_global_oce_in_p | tee tutorial_global_oce_in_p/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_in_p/testreport_out.txt' -threshold 9 "
+ # tutorial global oce lat lon
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_global_oce_latlon | tee tutorial_global_oce_latlon/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_latlon/testreport_out.txt' -threshold 10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,22 +16,22 @@ script:
  - echo `pwd`
  # aim.5l_cs
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t aim.5l_cs | tee aim.5l_cs/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'aim.5l_cs/testreport_out.txt' -threshold 14 14"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'aim.5l_cs/testreport_out.txt' -threshold 14 16"
  # global_ocean.cs32x15
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t global_ocean.cs32x15 | tee global_ocean.cs32x15/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'global_ocean.cs32x15/testreport_out.txt' -threshold 10 11 11 11 11"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'global_ocean.cs32x15/testreport_out.txt' -threshold 16 16 16 16 16"
  # global_ocean.90x40x15
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t global_ocean.90x40x15 | tee global_ocean.90x40x15/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'global_ocean.90x40x15/testreport_out.txt' -threshold 7 10 12"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'global_ocean.90x40x15/testreport_out.txt' -threshold 16 16 16"
  # hs94.cs-32x32x5
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t hs94.cs-32x32x5 | tee hs94.cs-32x32x5/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'hs94.cs-32x32x5/testreport_out.txt' -threshold 14 14" 
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'hs94.cs-32x32x5/testreport_out.txt' -threshold 13 16" 
  # isomip
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t isomip | tee isomip/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'isomip/testreport_out.txt' -threshold 11 10 10"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'isomip/testreport_out.txt' -threshold 16 16 16"
  # offline_exf_seaice
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t offline_exf_seaice | tee offline_exf_seaice/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'offline_exf_seaice/testreport_out.txt' -threshold 12 9 13 16 16"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'offline_exf_seaice/testreport_out.txt' -threshold 16 16 16 16 16"
  # tutorial advection in gyre
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_advection_in_gyre | tee tutorial_advection_in_gyre/testreport_out.txt"
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_advection_in_gyre/testreport_out.txt' -threshold 16"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,25 +16,25 @@ script:
  - echo `pwd`
  # tutorial advection in gyre
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_advection_in_gyre | tee tutorial_advection_in_gyre/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_advection_in_gyre/testreport_out.txt' -threshold 15"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_advection_in_gyre/testreport_out.txt' -threshold 16"
  # tutorial baroclinic gyre
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_baroclinic_gyre | tee tutorial_baroclinic_gyre/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_baroclinic_gyre/testreport_out.txt' -threshold 13"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_baroclinic_gyre/testreport_out.txt' -threshold 14"
  # tutorial barotropic gyre
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_barotropic_gyre | tee tutorial_barotropic_gyre/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_barotropic_gyre/testreport_out.txt' -threshold 15"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_barotropic_gyre/testreport_out.txt' -threshold 16"
  # tutorial cfc offline
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_cfc_offline | tee tutorial_cfc_offline/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_cfc_offline/testreport_out.txt' -threshold 15"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_cfc_offline/testreport_out.txt' -threshold 16"
  # tutorial deep convection
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_deep_convection | tee tutorial_deep_convection/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_deep_convection/testreport_out.txt' -threshold 15 15"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_deep_convection/testreport_out.txt' -threshold 16 16"
  # tutorial global oce biogeo
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_global_oce_biogeo | tee tutorial_global_oce_biogeo/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_biogeo/testreport_out.txt' -threshold 12"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_biogeo/testreport_out.txt' -threshold 16"
  # tutorial global oce in p
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_global_oce_in_p | tee tutorial_global_oce_in_p/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_in_p/testreport_out.txt' -threshold 9 "
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_in_p/testreport_out.txt' -threshold 16"
  # tutorial global oce lat lon
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_global_oce_latlon | tee tutorial_global_oce_latlon/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_latlon/testreport_out.txt' -threshold 10"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_latlon/testreport_out.txt' -threshold 16"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,27 @@ before_install:
 
 script: 
  - echo `pwd`
+ # aim.5l_cs
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t aim.5l_cs | tee aim.5l_cs/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'aim.5l_cs/testreport_out.txt' -threshold 14 14"
+ # global_ocean.cs32x15
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t global_ocean.cs32x15 | tee global_ocean.cs32x15/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'global_ocean.cs32x15/testreport_out.txt' -threshold 10 11 11 11 11"
+ # global_ocean.90x40x15
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t global_ocean.90x40x15 | tee global_ocean.90x40x15/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'global_ocean.90x40x15/testreport_out.txt' -threshold 7 10 12"
+ # hs94.cs-32x32x5
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t hs94.cs-32x32x5 | tee hs94.cs-32x32x5/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'hs94.cs-32x32x5/testreport_out.txt' -threshold 14 14" 
+ # isomip
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t isomip | tee isomip/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'isomip/testreport_out.txt' -threshold 11 10 10"
+ # offline_exf_seaice
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t offline_exf_seaice | tee offline_exf_seaice/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'offline_exf_seaice/testreport_out.txt' -threshold 12 9 13 16 16"
  # tutorial advection in gyre
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_advection_in_gyre | tee tutorial_advection_in_gyre/testreport_out.txt"
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_advection_in_gyre/testreport_out.txt' -threshold 16"
- # tutorial baroclinic gyre
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_baroclinic_gyre | tee tutorial_baroclinic_gyre/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_baroclinic_gyre/testreport_out.txt' -threshold 14"
- # tutorial barotropic gyre
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_barotropic_gyre | tee tutorial_barotropic_gyre/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_barotropic_gyre/testreport_out.txt' -threshold 16"
  # tutorial cfc offline
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_cfc_offline | tee tutorial_cfc_offline/testreport_out.txt"
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_cfc_offline/testreport_out.txt' -threshold 16"
@@ -35,6 +47,6 @@ script:
  # tutorial global oce in p
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_global_oce_in_p | tee tutorial_global_oce_in_p/testreport_out.txt"
  - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_in_p/testreport_out.txt' -threshold 16"
- # tutorial global oce lat lon
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_global_oce_latlon | tee tutorial_global_oce_latlon/testreport_out.txt"
- - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_global_oce_latlon/testreport_out.txt' -threshold 16"
+ # tutorial_plume_on_slope
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; ./testreport -t tutorial_plume_on_slope | tee tutorial_plume_on_slope/testreport_out.txt"
+ - docker exec -i fc11-testreport bash -c "cd /MITgcm/verification; python verification_parser.py -filename 'tutorial_plume_on_slope/testreport_out.txt' -threshold 16"

--- a/verification/verification_parser.py
+++ b/verification/verification_parser.py
@@ -49,6 +49,15 @@ def verification_parser(filename, threshold):
                 except ValueError:
                     pass
 
+
+            if len(dp_similarity) >= 17:
+                # this means that the test wasn't an offline advection test.
+                # Remove the means of u and v since they are constrained 
+                # to ~0 by domain geometry and can cause the test to fail 
+                # when it shouldn't.
+                del dp_similarity[15]
+                del dp_similarity[11]
+
             assert all(elements > threshold[j] for elements in dp_similarity)
 
 if __name__ == '__main__':

--- a/verification/verification_parser.py
+++ b/verification/verification_parser.py
@@ -1,8 +1,19 @@
 """Parse verification outputs."""
 
 import re
+import glob
+import os
 
 def verification_parser(filename, threshold):
+
+    # function should be given a threshold value for each sub test
+    (directory, _) = os.path.split(filename)
+    # how many additional tests are run with tweaks to this configuration
+    num_exps = len(glob.glob(directory+'/input.*'))+1
+
+    assert len(threshold)==num_exps
+
+    # open the testreport output to assess pass/fail            
     with open(filename) as f:
         lines = f.readlines()
 
@@ -16,23 +27,29 @@ def verification_parser(filename, threshold):
                     # but set to false to catch next matches.
                     first_match = False
                 else:
-                    test_results = lines[i+2]
+                    # save the line number where the output is found
+                    output_line = i
+                    break
 
-        # split test_results into a list with values for each number. 
-        # this uses spaces and the < > characters to separate the numbers.
-        test_results = re.split('[ ><]',test_results)
-        # ignore the Genmake, depend, make, and run checks, as well as
-        # the "pass" or "fail" and test name at the end of the line
-        test_results = test_results[4:-3]
-        # convert to floats
-        dp_similarity = []
-        for i, x in enumerate(test_results):
-            try:
-                dp_similarity.append(float(x))
-            except ValueError:
-                pass
+        # loop through each of the subexperiments:
+        for j in xrange(len(threshold)):
+            test_results = lines[output_line+2+j]
 
-        assert all(elements > threshold for elements in dp_similarity)
+            # split test_results into a list with values for each number. 
+            # this uses spaces and the < > characters to separate the numbers.
+            test_results = re.split('[ ><]',test_results)
+            # ignore the Genmake, depend, make, and run checks, as well as
+            # the "pass" or "fail" and test name at the end of the line
+            test_results = test_results[4:-3]
+            # convert to floats
+            dp_similarity = []
+            for i, x in enumerate(test_results):
+                try:
+                    dp_similarity.append(float(x))
+                except ValueError:
+                    pass
+
+            assert all(elements > threshold[j] for elements in dp_similarity)
 
 if __name__ == '__main__':
 
@@ -43,8 +60,8 @@ if __name__ == '__main__':
     parser.add_argument('-filename', type=str, 
                         help='path to output file from the verification test')
 
-    parser.add_argument('-threshold', type=int, default=15, 
-                        help='number of decimal places of similarity required for test to pass')
+    parser.add_argument('-threshold',nargs='+', type=int, default=15, 
+                        help='number of decimal places of similarity required for test to pass. Requires a value for each sub test. Separate values with a space.')
 
     args = parser.parse_args()
 

--- a/verification/verification_parser.py
+++ b/verification/verification_parser.py
@@ -58,7 +58,7 @@ def verification_parser(filename, threshold):
                 del dp_similarity[15]
                 del dp_similarity[11]
 
-            assert all(elements > threshold[j] for elements in dp_similarity)
+            assert all(elements >= threshold[j] for elements in dp_similarity)
 
 if __name__ == '__main__':
 

--- a/verification/verification_parser.py
+++ b/verification/verification_parser.py
@@ -11,8 +11,21 @@ def verification_parser(filename, threshold):
     # how many additional tests are run with tweaks to this configuration
     num_exps = len(glob.glob(directory+'/input.*'))+1
 
-    assert len(threshold)==num_exps
+    # check that the correct number of values for `threshold` have been given
+    if len(threshold) != num_exps:
+        # some if statements to deal with grammar
+        if len(threshold)==1:
+            error_message = '{0} value given for threshold, '.format(len(threshold))
+        else:
+            error_message = '{0} values given for threshold, '.format(len(threshold))
+        
+        if num_exps==1:
+            error_message = error_message + 'but {0} subtest found.'.format(num_exps)        
+        else:
+            error_message = error_message + 'but {0} subtests found.'.format(num_exps)
 
+        raise ValueError(error_message)
+        
     # open the testreport output to assess pass/fail            
     with open(filename) as f:
         lines = f.readlines()


### PR DESCRIPTION
The python function can now parse multiple subtests for each test, and can be passed a list of values for `threshold` (each value separated by a space from the one before it).

The list of experiments that Travis runs has been expanded to include all non-adjoint tutorials.

I chose the values for `threshold` based on what I needed to use to make the tests pass on my laptop. Feedback on whether these values are acceptable would be good.