### PR TITLE
add roles for linking to files and code search

### DIFF
--- a/doc/_extensions/mitgcm.py
+++ b/doc/_extensions/mitgcm.py
@@ -1,0 +1,12 @@
+from docutils import nodes
+
+def setup(app):
+    app.add_role('filelink', autolink('https://github.com/altMITgcm/MITgcm/blob/master/%s'))
+    app.add_role('varlink', autolink('http://mitgcm.org/lxr/ident/MITgcm?_i=%s'))
+
+def autolink(pattern):
+    def role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+        url = pattern % (text,)
+        node = nodes.reference(rawtext, text, refuri=url, **options)
+        return [node], []
+    return role

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,9 +16,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.abspath('.'), '_extensions'))
 
 
 # -- General configuration ------------------------------------------------
@@ -33,7 +33,8 @@
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.bibtex']
+    'sphinxcontrib.bibtex',
+    'mitgcm']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Add roles for linking to files/directories on github and to identifier code searches on our lxr page.
These are meant to replace the \filelink and \varlink LaTeX macros and can be used like this:
```
:filelink:`doc/tag-index`
:varlink:`uVel`
```
