### PR TITLE
fix equation numbers in online documentation

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
+git+https://github.com/sphinx-doc/sphinx.git@2e04c2a0
 sphinxcontrib-bibtex


### PR DESCRIPTION
This adds the (currently) latest development version of sphinx to the docs requirements so it will be used on readthedocs.  This version numbers equations by chapter and across pages in html output rather than by page.  An example build can be seen here: http://mitgcm-test.readthedocs.io/en/math-numfig/.