### PR TITLE
TEMPORARY FIX: Move equation numbers to the right

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,0 +1,17 @@
+/* Make equation numbers float to the right */
+.eqno {
+    margin-left: 5px;
+    float: right;
+}
+/* Hide the link... */
+.math .headerlink {
+    display: none;
+    visibility: hidden;
+}
+/* ...unless the equation is hovered */
+.math:hover .headerlink {
+    display: inline-block;
+    visibility: visible;
+    /* Place link in margin and keep equation number aligned with boundary */
+    margin-right: -0.7em;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -185,5 +185,7 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
+def setup(app):
+    app.add_stylesheet('css/custom.css')
 
 


### PR DESCRIPTION
This adds some css to move equation numbers from above the equation to the right with the sphinx_rtd_theme.  It is based on https://github.com/rtfd/sphinx_rtd_theme/pull/383 which may eventually make it unnecessary.  The result can be seen here: http://mitgcm-test.readthedocs.io/en/equation-numbers-right/index.html.  Vertical alignment is not optimal (top vs baseline) but this is the only solution I am aware of that reliably avoids overwriting of parts of the equation with the equation number and doesn't cause other alignment peculiarities.  When the page becomes too narrow for both equation and number, the number simply moves above the equation.
  
I cannot test this on IE, so if someone can, please do!