### PR TITLE
Add -q testreport and shorten .travis.yml

### DIFF
--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -1,0 +1,1 @@
+## Scripts used from Travis CI

--- a/tools/ci/runtr.sh
+++ b/tools/ci/runtr.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Test report running script for Travis CI 
+# - called from .travis.yml script: section with environment variables 
+#   already set.
+# MITGCM_DECMD - command to run under Docker
+# MITGCM_EXP   - MITgcm test to run
+# MITGCM_TROPT - Test report options
+#
+${MITGCM_DECMD} "cd /MITgcm/verification; ./testreport -t ${MITGCM_EXP} ${MITGCM_TROPT} | tee ${MITGCM_EXP}/testreport_out.txt"
+${MITGCM_DECMD} "cd /MITgcm/verification; python verification_parser.py -filename ${MITGCM_EXP}/testreport_out.txt -threshold ${MITGCM_PRECS}"


### PR DESCRIPTION
.travis.yml now calls external function for running
and checking each testreport experiment to reduce
repititious scripting.

.travis.yml call testreport -q at finish to generate
a summary.